### PR TITLE
파일 이름 생성기가 결정론적으로 동작하도록 수정

### DIFF
--- a/RimworldExtractorInternal/Utils.cs
+++ b/RimworldExtractorInternal/Utils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -16,21 +17,32 @@ namespace RimworldExtractorInternal
     {
         public static string GenerateFileName(string ModName, string TypeName)
         {
-            return ToBase36(HashCode.Combine(ModName, TypeName));
+            return ToBase36(GetDeterministicHash(ModName, TypeName));
         }
         
         public static string GenerateFileName(string ModName, string TypeName, string DefName)
         {
-            return ToBase36(HashCode.Combine(ModName, TypeName, DefName));
+            return ToBase36(GetDeterministicHash(ModName, TypeName, DefName));
         }
 
-        private static string ToBase36(long value)
+        public static uint GetDeterministicHash(params string[] inputs)
+        {
+            string inputCombined = string.Join("::", inputs);
+            byte[] inputBytes = Encoding.UTF8.GetBytes(inputCombined);
+            
+            // Deterministic Hashing
+            byte[] hashBytes = SHA256.HashData(inputBytes);
+            
+            return BitConverter.ToUInt32(hashBytes, 0);
+        }
+        
+        public static string ToBase36(uint value)
         {
             const string chars = "0123456789abcdefghijklmnopqrstuvwxyz";
             const int resultLength = 6;
-            int charsLength = chars.Length;
+            uint charsLength = (uint)chars.Length;
             
-            value = unchecked((uint)value) % 2176782336;
+            value = value % 2176782336u;
             char[] result = new char[resultLength];
             
             for (int i = resultLength - 1; i >= 0; i--)


### PR DESCRIPTION
이거 처음 만들때는 몰랐는데
HashCode가 한 프로세스 안에서만 결정론적이더라구요..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File names are now generated consistently across runs and environments.
  * Added support for generating unique file names using mod, type, and definition details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->